### PR TITLE
Added support for external Redis connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ aedesPersistenceRedis({
 })
 ```
 
+Alternatively, you can pass in an externally created Redis connection using the
+`conn` option. This can be useful when connecting to a Redis cluster, for example.
+
+Example:
+
+```js
+aedesPersistenceRedis({
+  conn: new Redis.Cluster([{
+    port: 6379,
+    host: '127.0.0.1'
+  }, {
+    port: 6380,
+    host: '127.0.0.1'
+  }])
+})
+```
+
 ### Changes in v4.x
 
 v4 has changed the subscriptions key schema to enhance performance. Please check [related PR](https://github.com/mcollina/aedes-persistence-redis/pull/31) for more details.

--- a/persistence.js
+++ b/persistence.js
@@ -36,7 +36,7 @@ function RedisPersistence (opts) {
 
   this.messageIdCache = HLRU(100000)
 
-  this._db = new Redis(opts)
+  this._db = opts.conn || new Redis(opts)
 
   this._getRetainedChunkBound = this._getRetainedChunk.bind(this)
   CachedPersistence.call(this, opts)


### PR DESCRIPTION
The main reason for this PR is to support connecting to Redis clusters. Currently, the `RedisPersistence` constructor assumes you will be creating a connection to a single Redis server and internally makes a call to `new Redis(opts)`. However, in order to connect to a Redis cluster, you must use the `Redis.Cluster` constructor of `ioredis`. This PR allows you to pass in any Redis instance as the value of a new `conn` option. This allows you to construct a new `Redis.Cluster` connection outside of the `RedisPersistence` constructor and pass it in as an argument.

NOTE: There is currently no unit test for this PR since I wasn't sure of the best approach to modifying `test.js` to create a new `Redis.Cluster` connection instead of a standard `Redis` connection. Suggestions?