### PR TITLE
chore: update CI to Node 14, 16 and 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
     services:
-            mongodb:
+            redis:
                 image: redis
                 ports:
                   - 6379:6379
                 options: --entrypoint redis-server
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on: 
   push:
     branches:


### PR DESCRIPTION
This PR updates CI to the most recent versions of NodeJS and the github actions used.

Kind regards,
Hans