### PR TITLE
chore: modernize to ES6

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,9 +1,9 @@
-var mq = require('mqemitter-redis')()
-var persistence = require('.')()
-var aedes = require('aedes')({
+const mq = require('mqemitter-redis')()
+const persistence = require('.')()
+const aedes = require('aedes')({
   mq,
   persistence
 })
-var server = require('net').createServer(aedes.handle)
+const server = require('net').createServer(aedes.handle)
 
 server.listen(1883)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "pre-commit": "^1.2.2",
     "release-it": "^14.0.3",
     "snazzy": "^9.0.0",
-    "standard": "^14.3.4",
+    "standard": "^17.0.0",
     "tape": "^4.13.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mcollina/aedes-persistence-redis.git"
+    "url": "git+https://github.com/moscajs/aedes-persistence-redis.git"
   },
   "keywords": [
     "mqtt",
@@ -43,9 +43,9 @@
   "author": "Matteo Collina <hello@matteocollina.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mcollina/aedes-persistence-redis/issues"
+    "url": "https://github.com/moscajs/aedes-persistence-redis/issues"
   },
-  "homepage": "https://github.com/mcollina/aedes-persistence-redis#readme",
+  "homepage": "https://github.com/moscajs/aedes-persistence-redis#readme",
   "devDependencies": {
     "fastq": "^1.13.0",
     "faucet": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -47,28 +47,26 @@
   },
   "homepage": "https://github.com/mcollina/aedes-persistence-redis#readme",
   "devDependencies": {
-    "concat-stream": "^2.0.0",
-    "fastq": "^1.8.0",
+    "fastq": "^1.13.0",
     "faucet": "0.0.1",
     "license-checker": "^25.0.1",
-    "mqemitter": "^4.4.0",
-    "mqemitter-redis": "^4.0.3",
-    "mqtt": "^4.2.1",
+    "mqemitter": "^4.5.0",
+    "mqemitter-redis": "^5.0.0",
+    "mqtt": "^4.3.7",
     "nyc": "^15.1.0",
     "pre-commit": "^1.2.2",
-    "release-it": "^14.0.3",
+    "release-it": "^15.0.0",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
-    "tape": "^4.13.2"
+    "tape": "^4.15.1"
   },
   "dependencies": {
-    "aedes-cached-persistence": "^8.1.0",
-    "from2": "^2.3.0",
+    "aedes-cached-persistence": "^8.1.1",
     "hashlru": "^2.3.0",
-    "ioredis": "^4.17.3",
+    "ioredis": "^5.0.4",
     "msgpack-lite": "^0.1.26",
     "pump": "^3.0.0",
-    "qlobber": "^5.0.3",
+    "qlobber": "^7.0.0",
     "through2": "^4.0.2",
     "throughv": "^1.0.4"
   }

--- a/persistence.js
+++ b/persistence.js
@@ -6,7 +6,6 @@ const msgpack = require('msgpack-lite')
 const pump = require('pump')
 const CachedPersistence = require('aedes-cached-persistence')
 const Packet = CachedPersistence.Packet
-const inherits = require('util').inherits
 const HLRU = require('hashlru')
 const QlobberTrue = require('qlobber').QlobberTrue
 const qlobberOpts = {
@@ -24,70 +23,488 @@ const outgoingKey = 'outgoing:'
 const outgoingIdKey = 'outgoing-id:'
 const incomingKey = 'incoming:'
 
-function RedisPersistence (opts) {
-  if (!(this instanceof RedisPersistence)) {
-    return new RedisPersistence(opts)
-  }
+class RedisPersistence extends CachedPersistence {
+  constructor (opts = {}) {
+    super()
+    this.maxSessionDelivery = opts.maxSessionDelivery || 1000
+    this.packetTTL = opts.packetTTL || (() => { return 0 })
 
-  opts = opts || {}
-  this.maxSessionDelivery = opts.maxSessionDelivery || 1000
-  this.packetTTL = opts.packetTTL || (() => { return 0 })
+    this.messageIdCache = HLRU(100000)
 
-  this.messageIdCache = HLRU(100000)
-
-  if (opts.cluster) {
-    this._db = new Redis.Cluster(opts.cluster)
-  } else {
-    this._db = opts.conn || new Redis(opts)
-  }
-
-  this._getRetainedChunkBound = this._getRetainedChunk.bind(this)
-  CachedPersistence.call(this, opts)
-}
-
-inherits(RedisPersistence, CachedPersistence)
-
-RedisPersistence.prototype.storeRetained = function (packet, cb) {
-  if (packet.payload.length === 0) {
-    this._db.hdel(retainedKey, packet.topic, cb)
-  } else {
-    this._db.hset(retainedKey, packet.topic, msgpack.encode(packet), cb)
-  }
-}
-
-RedisPersistence.prototype._getRetainedChunk = function (chunk, enc, cb) {
-  this._db.hgetBuffer(retainedKey, chunk, cb)
-}
-
-RedisPersistence.prototype.createRetainedStreamCombi = function (patterns) {
-  const that = this
-  const qlobber = new QlobberTrue(qlobberOpts)
-
-  for (let i = 0; i < patterns.length; i++) {
-    qlobber.add(patterns[i])
-  }
-
-  const stream = through.obj(that._getRetainedChunkBound)
-
-  this._db.hkeys(retainedKey, function getKeys (err, keys) {
-    if (err) {
-      stream.emit('error', err)
+    if (opts.cluster) {
+      this._db = new Redis.Cluster(opts.cluster)
     } else {
-      matchRetained(stream, keys, qlobber)
+      this._db = opts.conn || new Redis(opts)
     }
-  })
 
-  return pump(stream, throughv.obj(decodeRetainedPacket))
-}
+    this._getRetainedChunkBound = this._getRetainedChunk.bind(this)
+    CachedPersistence.call(this, opts)
+  }
 
-RedisPersistence.prototype.createRetainedStream = function (pattern) {
-  return this.createRetainedStreamCombi([pattern])
+  storeRetained (packet, cb) {
+    if (packet.payload.length === 0) {
+      this._db.hdel(retainedKey, packet.topic, cb)
+    } else {
+      this._db.hset(retainedKey, packet.topic, msgpack.encode(packet), cb)
+    }
+  }
+
+  _getRetainedChunk (chunk, enc, cb) {
+    this._db.hgetBuffer(retainedKey, chunk, cb)
+  }
+
+  createRetainedStreamCombi (patterns) {
+    const that = this
+    const qlobber = new QlobberTrue(qlobberOpts)
+
+    for (const pattern of patterns) {
+      qlobber.add(pattern)
+    }
+
+    const stream = through.obj(that._getRetainedChunkBound)
+
+    this._db.hkeys(retainedKey, function getKeys (err, keys) {
+      if (err) {
+        stream.emit('error', err)
+      } else {
+        matchRetained(stream, keys, qlobber)
+      }
+    })
+
+    return pump(stream, throughv.obj(decodeRetainedPacket))
+  }
+
+  createRetainedStream (pattern) {
+    return this.createRetainedStreamCombi([pattern])
+  }
+
+  addSubscriptions (client, subs, cb) {
+    if (!this.ready) {
+      this.once('ready', this.addSubscriptions.bind(this, client, subs, cb))
+      return
+    }
+
+    const clientSubKey = clientKey + client.id
+
+    const toStore = {}
+    let published = 0
+    let errored
+
+    for (const sub of subs) {
+      toStore[sub.topic] = sub.qos
+    }
+
+    this._db.sadd(clientsKey, client.id, finish)
+    this._db.hmset(clientSubKey, toStore, finish)
+
+    this._addedSubscriptions(client, subs, finish)
+
+    function finish (err) {
+      errored = err
+      published++
+      if (published === 3) {
+        cb(errored, client)
+      }
+    }
+  }
+
+  removeSubscriptions (client, subs, cb) {
+    if (!this.ready) {
+      this.once('ready', this.removeSubscriptions.bind(this, client, subs, cb))
+      return
+    }
+
+    const clientSubKey = clientKey + client.id
+
+    let errored = false
+    let outstanding = 0
+
+    function check (err) {
+      if (err) {
+        if (!errored) {
+          errored = true
+          cb(err)
+        }
+      }
+
+      if (errored) {
+        return
+      }
+
+      outstanding--
+      if (outstanding === 0) {
+        cb(null, client)
+      }
+    }
+
+    const that = this
+    this._db.hdel(clientSubKey, subs, function subKeysRemoved (err) {
+      if (err) {
+        return cb(err)
+      }
+
+      outstanding++
+      that._db.exists(clientSubKey, function checkAllSubsRemoved (err, subCount) {
+        if (err) {
+          return check(err)
+        }
+        if (subCount === 0) {
+          outstanding++
+          that._db.del(outgoingKey + client.id, check)
+          return that._db.srem(clientsKey, client.id, check)
+        }
+        check()
+      })
+
+      outstanding++
+      that._removedSubscriptions(client, subs.map(toSub), check)
+    })
+  }
+
+  subscriptionsByClient (client, cb) {
+    const clientSubKey = clientKey + client.id
+
+    this._db.hgetall(clientSubKey, function returnSubs (err, subs) {
+      const toReturn = returnSubsForClient(subs)
+      cb(err, toReturn.length > 0 ? toReturn : null, client)
+    })
+  }
+
+  countOffline (cb) {
+    const that = this
+
+    this._db.scard(clientsKey, function countOfflineClients (err, count) {
+      if (err) {
+        return cb(err)
+      }
+
+      cb(null, that._trie.subscriptionsCount, parseInt(count) || 0)
+    })
+  }
+
+  subscriptionsByTopic (topic, cb) {
+    if (!this.ready) {
+      this.once('ready', this.subscriptionsByTopic.bind(this, topic, cb))
+      return this
+    }
+
+    const result = this._trie.match(topic)
+
+    cb(null, result)
+  }
+
+  _setup () {
+    if (this.ready) {
+      return
+    }
+
+    const that = this
+
+    const hgetallStream = throughv.obj(function getStream (clientId, enc, cb) {
+      const clientSubKey = clientKey + clientId
+      that._db.hgetall(clientSubKey, function clientHash (err, hash) {
+        cb(err, { clientHash: hash, clientId })
+      })
+    }, function emitReady (cb) {
+      that.ready = true
+      that.emit('ready')
+      cb()
+    }).on('data', function processKeys (data) {
+      processKeysForClient(data.clientId, data.clientHash, that)
+    })
+
+    this._db.smembers(clientsKey, function smembers (err, clientIds) {
+      if (err) {
+        hgetallStream.emit('error', err)
+      } else {
+        for (const clientId of clientIds) {
+          hgetallStream.write(clientId)
+        }
+        hgetallStream.end()
+      }
+    })
+  }
+
+  outgoingEnqueue (sub, packet, cb) {
+    this.outgoingEnqueueCombi([sub], packet, cb)
+  }
+
+  outgoingEnqueueCombi (subs, packet, cb) {
+    if (!subs || subs.length === 0) {
+      return cb(null, packet)
+    }
+    let count = 0
+    let outstanding = 1
+    let errored = false
+    const packetKey = `packet:${packet.brokerId}:${packet.brokerCounter}`
+    const countKey = `packet:${packet.brokerId}:${packet.brokerCounter}:offlineCount`
+    const ttl = this.packetTTL(packet)
+
+    const encoded = msgpack.encode(new Packet(packet))
+
+    this._db.mset(packetKey, encoded, countKey, subs.length, finish)
+    if (ttl > 0) {
+      outstanding += 2
+      this._db.expire(packetKey, ttl, finish)
+      this._db.expire(countKey, ttl, finish)
+    }
+
+    for (const sub of subs) {
+      const listKey = outgoingKey + sub.clientId
+      this._db.rpush(listKey, packetKey, finish)
+    }
+
+    function finish (err) {
+      count++
+      if (err) {
+        errored = err
+        return cb(err)
+      }
+      if (count === (subs.length + outstanding) && !errored) {
+        cb(null, packet)
+      }
+    }
+  }
+
+  outgoingUpdate (client, packet, cb) {
+    const that = this
+    if (packet.brokerId && packet.messageId) {
+      updateWithClientData(this, client, packet, cb)
+    } else {
+      augmentWithBrokerData(this, client, packet, function updateClient (err) {
+        if (err) { return cb(err, client, packet) }
+
+        updateWithClientData(that, client, packet, cb)
+      })
+    }
+  }
+
+  outgoingClearMessageId (client, packet, cb) {
+    const that = this
+    const clientListKey = outgoingKey + client.id
+    const messageIdKey = `${outgoingIdKey + client.id}:${packet.messageId}`
+
+    const clientKey = this.messageIdCache.get(messageIdKey)
+    this.messageIdCache.remove(messageIdKey)
+
+    if (!clientKey) {
+      return cb(null, packet)
+    }
+
+    let count = 0
+    let errored = false
+
+    // TODO can be cached in case of wildcard deliveries
+    this._db.getBuffer(clientKey, function clearMessageId (err, buf) {
+      let origPacket
+      let packetKey
+      let countKey
+      if (err) {
+        errored = err
+        return cb(err)
+      }
+      if (buf) {
+        origPacket = msgpack.decode(buf)
+        origPacket.messageId = packet.messageId
+
+        packetKey = `packet:${origPacket.brokerId}:${origPacket.brokerCounter}`
+        countKey = `packet:${origPacket.brokerId}:${origPacket.brokerCounter}:offlineCount`
+
+        if (clientKey !== packetKey) { // qos=2
+          that._db.del(clientKey, finish)
+        } else {
+          finish()
+        }
+      } else {
+        finish()
+      }
+
+      that._db.lrem(clientListKey, 0, packetKey, finish)
+
+      that._db.decr(countKey, (err, remained) => {
+        if (err) {
+          errored = err
+          return cb(err)
+        }
+        if (remained === 0) {
+          that._db.del(packetKey, countKey, finish)
+        } else {
+          finish()
+        }
+      })
+
+      function finish (err) {
+        count++
+        if (err) {
+          errored = err
+          return cb(err)
+        }
+        if (count === 3 && !errored) {
+          cb(err, origPacket)
+        }
+      }
+    })
+  }
+
+  outgoingStream (client) {
+    const clientListKey = outgoingKey + client.id
+    const stream = throughv.obj(this._buildAugment(clientListKey))
+
+    this._db.lrange(clientListKey, 0, this.maxSessionDelivery, lrangeResult)
+
+    function lrangeResult (err, results) {
+      if (err) {
+        stream.emit('error', err)
+      } else {
+        for (const result of results) {
+          stream.write(result)
+        }
+        stream.end()
+      }
+    }
+
+    return stream
+  }
+
+  incomingStorePacket (client, packet, cb) {
+    const key = `${incomingKey + client.id}:${packet.messageId}`
+    const newp = new Packet(packet)
+    newp.messageId = packet.messageId
+    this._db.set(key, msgpack.encode(newp), cb)
+  }
+
+  incomingGetPacket (client, packet, cb) {
+    const key = `${incomingKey + client.id}:${packet.messageId}`
+    this._db.getBuffer(key, function decodeBuffer (err, buf) {
+      if (err) {
+        return cb(err)
+      }
+
+      if (!buf) {
+        return cb(new Error('no such packet'))
+      }
+
+      cb(null, msgpack.decode(buf), client)
+    })
+  }
+
+  incomingDelPacket (client, packet, cb) {
+    const key = `${incomingKey + client.id}:${packet.messageId}`
+    this._db.del(key, cb)
+  }
+
+  putWill (client, packet, cb) {
+    const key = `${willKey + this.broker.id}:${client.id}`
+    packet.clientId = client.id
+    packet.brokerId = this.broker.id
+    this._db.rpush(willsKey, key)
+    this._db.setBuffer(key, msgpack.encode(packet), encodeBuffer)
+
+    function encodeBuffer (err) {
+      cb(err, client)
+    }
+  }
+
+  getWill (client, cb) {
+    const key = `${willKey + this.broker.id}:${client.id}`
+    this._db.getBuffer(key, function getWillForClient (err, packet) {
+      if (err) { return cb(err) }
+
+      let result = null
+
+      if (packet) {
+        result = msgpack.decode(packet)
+      }
+
+      cb(null, result, client)
+    })
+  }
+
+  delWill (client, cb) {
+    const key = `${willKey + client.brokerId}:${client.id}`
+    let result = null
+    const that = this
+    this._db.lrem(willsKey, 0, key)
+    this._db.getBuffer(key, function getClientWill (err, packet) {
+      if (err) { return cb(err) }
+
+      if (packet) {
+        result = msgpack.decode(packet)
+      }
+
+      that._db.del(key, function deleteWill (err) {
+        cb(err, result, client)
+      })
+    })
+  }
+
+  streamWill (brokers) {
+    const stream = throughv.obj(this._buildAugment(willsKey))
+
+    this._db.lrange(willsKey, 0, 10000, streamWill)
+
+    function streamWill (err, results) {
+      if (err) {
+        stream.emit('error', err)
+      } else {
+        for (const result of results) {
+          if (!brokers || !brokers[result.split(':')[1]]) {
+            stream.write(result)
+          }
+        }
+        stream.end()
+      }
+    }
+    return stream
+  }
+
+  getClientList (topic) {
+    let entries = this._trie.match(topic, topic)
+
+    function pushClientList (size, next) {
+      if (entries.length === 0) {
+        return next(null, null)
+      }
+      const chunk = entries.slice(0, 1)
+      entries = entries.slice(1)
+      next(null, chunk[0].clientId)
+    }
+
+    return from.obj(pushClientList)
+  }
+
+  _buildAugment (listKey) {
+    const that = this
+    return function decodeAndAugment (key, enc, cb) {
+      that._db.getBuffer(key, function decodeMessage (err, result) {
+        let decoded
+        if (result) {
+          decoded = msgpack.decode(result)
+        }
+        if (err || !decoded) {
+          that._db.lrem(listKey, 0, key)
+        }
+        cb(err, decoded)
+      })
+    }
+  }
+
+  destroy (cb) {
+    const that = this
+    CachedPersistence.prototype.destroy.call(this, function disconnect () {
+      that._db.disconnect()
+
+      if (cb) {
+        that._db.on('end', cb)
+      }
+    })
+  }
 }
 
 function matchRetained (stream, keys, qlobber) {
-  for (let i = 0, l = keys.length; i < l; i++) {
-    if (qlobber.test(keys[i])) {
-      stream.write(keys[i])
+  for (const key of keys) {
+    if (qlobber.test(key)) {
+      stream.write(key)
     }
   }
   stream.end()
@@ -97,102 +514,10 @@ function decodeRetainedPacket (chunk, enc, cb) {
   cb(null, msgpack.decode(chunk))
 }
 
-RedisPersistence.prototype.addSubscriptions = function (client, subs, cb) {
-  if (!this.ready) {
-    this.once('ready', this.addSubscriptions.bind(this, client, subs, cb))
-    return
-  }
-
-  const clientSubKey = clientKey + client.id
-
-  const toStore = {}
-  let published = 0
-  let errored
-
-  for (const sub of subs) {
-    toStore[sub.topic] = sub.qos
-  }
-
-  this._db.sadd(clientsKey, client.id, finish)
-  this._db.hmset(clientSubKey, toStore, finish)
-
-  this._addedSubscriptions(client, subs, finish)
-
-  function finish (err) {
-    errored = err
-    published++
-    if (published === 3) {
-      cb(errored, client)
-    }
-  }
-}
-
-RedisPersistence.prototype.removeSubscriptions = function (client, subs, cb) {
-  if (!this.ready) {
-    this.once('ready', this.removeSubscriptions.bind(this, client, subs, cb))
-    return
-  }
-
-  const clientSubKey = clientKey + client.id
-
-  let errored = false
-  let outstanding = 0
-
-  function check (err) {
-    if (err) {
-      if (!errored) {
-        errored = true
-        cb(err)
-      }
-    }
-
-    if (errored) {
-      return
-    }
-
-    outstanding--
-    if (outstanding === 0) {
-      cb(null, client)
-    }
-  }
-
-  const that = this
-  this._db.hdel(clientSubKey, subs, function subKeysRemoved (err) {
-    if (err) {
-      return cb(err)
-    }
-
-    outstanding++
-    that._db.exists(clientSubKey, function checkAllSubsRemoved (err, subCount) {
-      if (err) {
-        return check(err)
-      }
-      if (subCount === 0) {
-        outstanding++
-        that._db.del(outgoingKey + client.id, check)
-        return that._db.srem(clientsKey, client.id, check)
-      }
-      check()
-    })
-
-    outstanding++
-    that._removedSubscriptions(client, subs.map(toSub), check)
-  })
-}
-
 function toSub (topic) {
   return {
     topic
   }
-}
-
-RedisPersistence.prototype.subscriptionsByClient = function (client, cb) {
-  const clientSubKey = clientKey + client.id
-
-  this._db.hgetall(clientSubKey, function returnSubs (err, subs) {
-    const toReturn = returnSubsForClient(subs)
-    cb(err, toReturn.length > 0 ? toReturn : null, client)
-  })
 }
 
 function returnSubsForClient (subs) {
@@ -204,69 +529,14 @@ function returnSubsForClient (subs) {
     return toReturn
   }
 
-  for (let i = 0; i < subKeys.length; i++) {
+  for (const subKey of subKeys) {
     toReturn.push({
-      topic: subKeys[i],
-      qos: parseInt(subs[subKeys[i]])
+      topic: subKey,
+      qos: parseInt(subs[subKey])
     })
   }
 
   return toReturn
-}
-
-RedisPersistence.prototype.countOffline = function (cb) {
-  const that = this
-
-  this._db.scard(clientsKey, function countOfflineClients (err, count) {
-    if (err) {
-      return cb(err)
-    }
-
-    cb(null, that._trie.subscriptionsCount, parseInt(count) || 0)
-  })
-}
-
-RedisPersistence.prototype.subscriptionsByTopic = function (topic, cb) {
-  if (!this.ready) {
-    this.once('ready', this.subscriptionsByTopic.bind(this, topic, cb))
-    return this
-  }
-
-  const result = this._trie.match(topic)
-
-  cb(null, result)
-}
-
-RedisPersistence.prototype._setup = function () {
-  if (this.ready) {
-    return
-  }
-
-  const that = this
-
-  const hgetallStream = throughv.obj(function getStream (clientId, enc, cb) {
-    const clientSubKey = clientKey + clientId
-    that._db.hgetall(clientSubKey, function clientHash (err, hash) {
-      cb(err, { clientHash: hash, clientId })
-    })
-  }, function emitReady (cb) {
-    that.ready = true
-    that.emit('ready')
-    cb()
-  }).on('data', function processKeys (data) {
-    processKeysForClient(data.clientId, data.clientHash, that)
-  })
-
-  this._db.smembers(clientsKey, function smembers (err, clientIds) {
-    if (err) {
-      hgetallStream.emit('error', err)
-    } else {
-      for (let i = 0, l = clientIds.length; i < l; i++) {
-        hgetallStream.write(clientIds[i])
-      }
-      hgetallStream.end()
-    }
-  })
 }
 
 function processKeysForClient (clientId, clientHash, that) {
@@ -278,47 +548,6 @@ function processKeysForClient (clientId, clientHash, that) {
       topic,
       qos: clientHash[topic]
     })
-  }
-}
-
-RedisPersistence.prototype.outgoingEnqueue = function (sub, packet, cb) {
-  this.outgoingEnqueueCombi([sub], packet, cb)
-}
-
-RedisPersistence.prototype.outgoingEnqueueCombi = function (subs, packet, cb) {
-  if (!subs || subs.length === 0) {
-    return cb(null, packet)
-  }
-  let count = 0
-  let outstanding = 1
-  let errored = false
-  const packetKey = `packet:${packet.brokerId}:${packet.brokerCounter}`
-  const countKey = `packet:${packet.brokerId}:${packet.brokerCounter}:offlineCount`
-  const ttl = this.packetTTL(packet)
-
-  const encoded = msgpack.encode(new Packet(packet))
-
-  this._db.mset(packetKey, encoded, countKey, subs.length, finish)
-  if (ttl > 0) {
-    outstanding += 2
-    this._db.expire(packetKey, ttl, finish)
-    this._db.expire(countKey, ttl, finish)
-  }
-
-  for (let i = 0; i < subs.length; i++) {
-    const listKey = outgoingKey + subs[i].clientId
-    this._db.rpush(listKey, packetKey, finish)
-  }
-
-  function finish (err) {
-    count++
-    if (err) {
-      errored = err
-      return cb(err)
-    }
-    if (count === (subs.length + outstanding) && !errored) {
-      cb(null, packet)
-    }
   }
 }
 
@@ -406,238 +635,4 @@ function augmentWithBrokerData (that, client, packet, cb) {
   cb(null)
 }
 
-RedisPersistence.prototype.outgoingUpdate = function (client, packet, cb) {
-  const that = this
-  if (packet.brokerId && packet.messageId) {
-    updateWithClientData(this, client, packet, cb)
-  } else {
-    augmentWithBrokerData(this, client, packet, function updateClient (err) {
-      if (err) { return cb(err, client, packet) }
-
-      updateWithClientData(that, client, packet, cb)
-    })
-  }
-}
-
-RedisPersistence.prototype.outgoingClearMessageId = function (client, packet, cb) {
-  const that = this
-  const clientListKey = outgoingKey + client.id
-  const messageIdKey = `${outgoingIdKey + client.id}:${packet.messageId}`
-
-  const clientKey = this.messageIdCache.get(messageIdKey)
-  this.messageIdCache.remove(messageIdKey)
-
-  if (!clientKey) {
-    return cb(null, packet)
-  }
-
-  let count = 0
-  let errored = false
-
-  // TODO can be cached in case of wildcard deliveries
-  this._db.getBuffer(clientKey, function clearMessageId (err, buf) {
-    let origPacket
-    let packetKey
-    let countKey
-    if (err) {
-      errored = err
-      return cb(err)
-    }
-    if (buf) {
-      origPacket = msgpack.decode(buf)
-      origPacket.messageId = packet.messageId
-
-      packetKey = `packet:${origPacket.brokerId}:${origPacket.brokerCounter}`
-      countKey = `packet:${origPacket.brokerId}:${origPacket.brokerCounter}:offlineCount`
-
-      if (clientKey !== packetKey) { // qos=2
-        that._db.del(clientKey, finish)
-      } else {
-        finish()
-      }
-    } else {
-      finish()
-    }
-
-    that._db.lrem(clientListKey, 0, packetKey, finish)
-
-    that._db.decr(countKey, (err, remained) => {
-      if (err) {
-        errored = err
-        return cb(err)
-      }
-      if (remained === 0) {
-        that._db.del(packetKey, countKey, finish)
-      } else {
-        finish()
-      }
-    })
-
-    function finish (err) {
-      count++
-      if (err) {
-        errored = err
-        return cb(err)
-      }
-      if (count === 3 && !errored) {
-        cb(err, origPacket)
-      }
-    }
-  })
-}
-
-RedisPersistence.prototype.outgoingStream = function (client) {
-  const clientListKey = outgoingKey + client.id
-  const stream = throughv.obj(this._buildAugment(clientListKey))
-
-  this._db.lrange(clientListKey, 0, this.maxSessionDelivery, lrangeResult)
-
-  function lrangeResult (err, results) {
-    if (err) {
-      stream.emit('error', err)
-    } else {
-      for (let i = 0, l = results.length; i < l; i++) {
-        stream.write(results[i])
-      }
-      stream.end()
-    }
-  }
-
-  return stream
-}
-
-RedisPersistence.prototype.incomingStorePacket = function (client, packet, cb) {
-  const key = `${incomingKey + client.id}:${packet.messageId}`
-  const newp = new Packet(packet)
-  newp.messageId = packet.messageId
-  this._db.set(key, msgpack.encode(newp), cb)
-}
-
-RedisPersistence.prototype.incomingGetPacket = function (client, packet, cb) {
-  const key = `${incomingKey + client.id}:${packet.messageId}`
-  this._db.getBuffer(key, function decodeBuffer (err, buf) {
-    if (err) {
-      return cb(err)
-    }
-
-    if (!buf) {
-      return cb(new Error('no such packet'))
-    }
-
-    cb(null, msgpack.decode(buf), client)
-  })
-}
-
-RedisPersistence.prototype.incomingDelPacket = function (client, packet, cb) {
-  const key = `${incomingKey + client.id}:${packet.messageId}`
-  this._db.del(key, cb)
-}
-
-RedisPersistence.prototype.putWill = function (client, packet, cb) {
-  const key = `${willKey + this.broker.id}:${client.id}`
-  packet.clientId = client.id
-  packet.brokerId = this.broker.id
-  this._db.rpush(willsKey, key)
-  this._db.setBuffer(key, msgpack.encode(packet), encodeBuffer)
-
-  function encodeBuffer (err) {
-    cb(err, client)
-  }
-}
-
-RedisPersistence.prototype.getWill = function (client, cb) {
-  const key = `${willKey + this.broker.id}:${client.id}`
-  this._db.getBuffer(key, function getWillForClient (err, packet) {
-    if (err) { return cb(err) }
-
-    let result = null
-
-    if (packet) {
-      result = msgpack.decode(packet)
-    }
-
-    cb(null, result, client)
-  })
-}
-
-RedisPersistence.prototype.delWill = function (client, cb) {
-  const key = `${willKey + client.brokerId}:${client.id}`
-  let result = null
-  const that = this
-  this._db.lrem(willsKey, 0, key)
-  this._db.getBuffer(key, function getClientWill (err, packet) {
-    if (err) { return cb(err) }
-
-    if (packet) {
-      result = msgpack.decode(packet)
-    }
-
-    that._db.del(key, function deleteWill (err) {
-      cb(err, result, client)
-    })
-  })
-}
-
-RedisPersistence.prototype.streamWill = function (brokers) {
-  const stream = throughv.obj(this._buildAugment(willsKey))
-
-  this._db.lrange(willsKey, 0, 10000, streamWill)
-
-  function streamWill (err, results) {
-    if (err) {
-      stream.emit('error', err)
-    } else {
-      for (let i = 0, l = results.length; i < l; i++) {
-        if (!brokers || !brokers[results[i].split(':')[1]]) {
-          stream.write(results[i])
-        }
-      }
-      stream.end()
-    }
-  }
-  return stream
-}
-
-RedisPersistence.prototype.getClientList = function (topic) {
-  let entries = this._trie.match(topic, topic)
-
-  function pushClientList (size, next) {
-    if (entries.length === 0) {
-      return next(null, null)
-    }
-    const chunk = entries.slice(0, 1)
-    entries = entries.slice(1)
-    next(null, chunk[0].clientId)
-  }
-
-  return from.obj(pushClientList)
-}
-
-RedisPersistence.prototype._buildAugment = function (listKey) {
-  const that = this
-  return function decodeAndAugment (key, enc, cb) {
-    that._db.getBuffer(key, function decodeMessage (err, result) {
-      let decoded
-      if (result) {
-        decoded = msgpack.decode(result)
-      }
-      if (err || !decoded) {
-        that._db.lrem(listKey, 0, key)
-      }
-      cb(err, decoded)
-    })
-  }
-}
-
-RedisPersistence.prototype.destroy = function (cb) {
-  const that = this
-  CachedPersistence.prototype.destroy.call(this, function disconnect () {
-    that._db.disconnect()
-
-    if (cb) {
-      that._db.on('end', cb)
-    }
-  })
-}
-
-module.exports = RedisPersistence
+module.exports = (opts) => new RedisPersistence(opts)

--- a/persistence.js
+++ b/persistence.js
@@ -25,7 +25,7 @@ const incomingKey = 'incoming:'
 
 class RedisPersistence extends CachedPersistence {
   constructor (opts = {}) {
-    super()
+    super(opts)
     this.maxSessionDelivery = opts.maxSessionDelivery || 1000
     this.packetTTL = opts.packetTTL || (() => { return 0 })
 
@@ -38,7 +38,6 @@ class RedisPersistence extends CachedPersistence {
     }
 
     this._getRetainedChunkBound = this._getRetainedChunk.bind(this)
-    CachedPersistence.call(this, opts)
   }
 
   storeRetained (packet, cb) {

--- a/tester.js
+++ b/tester.js
@@ -1,18 +1,16 @@
 // npm install mqtt fastq
 // command to run : node fastbench 25000
-'use strict'
-
-var queue = require('fastq')(worker, 1)
-var mqtt = require('mqtt')
-var connected = 1
-var clients = []
-var count = 0
-var subscriptions = 0
-var st = Date.now()
+const queue = require('fastq')(worker, 1)
+const mqtt = require('mqtt')
+let connected = 1
+const clients = []
+let count = 0
+let subscriptions = 0
+const st = Date.now()
 console.log('Started connecting clients', st)
 
-setInterval(function () {
-  console.log(new Date() + '-' + count + ' - ' + subscriptions)
+setInterval(() => {
+  console.log(`${new Date()}-${count} - ${subscriptions}`)
 }, 1000)
 
 function worker (arg, cb) {
@@ -20,23 +18,21 @@ function worker (arg, cb) {
     port: 1883,
     keepalive: 60
   })
-  clients[count].on('connect',
-    (function (clientObj) {
-      return function () {
-        connected++
-        if (connected === process.argv[2]) {
-          console.log('done connecting clients', Date.now() - st)
-        }
-        clientObj.subscribe(clientObj.options.clientId, function () {
-          subscriptions++
-        })
-        cb(null, 42 * 2)
+  clients[count].on('connect', (clientObj => {
+    return () => {
+      connected++
+      if (connected === process.argv[2]) {
+        console.log('done connecting clients', Date.now() - st)
       }
-    }(clients[count]))
-  )
+      clientObj.subscribe(clientObj.options.clientId, () => {
+        subscriptions++
+      })
+      cb(null, 42 * 2)
+    }
+  })(clients[count]))
   count++
 }
 
-for (var i = 0; i < process.argv[2]; i++) {
-  queue.push(42, function () {})
+for (let i = 0; i < process.argv[2]; i++) {
+  queue.push(42, () => {})
 }


### PR DESCRIPTION
Hi,

this PR aims to bring the module to current state of the art:

- [X]  update depencencies (except for tape as `aedes-cached-persistence` is still using an pre 9.0.3 version of `aedes persistence`
- [X] update github links to point to `moscajs`
- [X] convert to ES6 ( including classes etc)
- [X] remove legacy stream modules where possible

Kind regards,
Hans