### PR TITLE
fix: invalid client id in test.js

### DIFF
--- a/test.js
+++ b/test.js
@@ -123,7 +123,7 @@ test('outgoingUpdate doesn\'t clear packet ttl', t => {
     id: 'ttlTest'
   }
   const subs = [{
-    clientId: client.clientId,
+    clientId: client.id,
     topic: 'hello',
     qos: 1
   }]


### PR DESCRIPTION
This PR fixes the invalid client Id in test.js as found while researching https://github.com/moscajs/aedes-persistence-redis/issues/98

Kind regards,
Hans