### PR TITLE
fix: don't use broker id from client object

### DIFF
--- a/persistence.js
+++ b/persistence.js
@@ -515,7 +515,7 @@ class RedisPersistence extends CachedPersistence {
   }
 
   delWill (client, cb) {
-    const key = willKey(client.brokerId, client.id)
+    const key = willKey(this.broker.id, client.id)
     let result = null
     const that = this
     this._db.lrem(WILLSKEY, 0, key)

--- a/test.js
+++ b/test.js
@@ -304,6 +304,38 @@ test('wills table de-duplicate', t => {
   }
 })
 
+test('wills get deleted', t => {
+  t.plan(1)
+  db.flushall()
+  const emitter = mqemitterRedis()
+  const instance = persistence()
+  const client = { id: 'delWillTest' }
+
+  instance.broker = toBroker('1', emitter)
+
+  const packet = {
+    cmd: 'publish',
+    topic: 'hello',
+    payload: 'delWillTest',
+    qos: 1,
+    retain: false,
+    brokerId: instance.broker.id,
+    brokerCounter: 42,
+    messageId: 123
+  }
+
+  instance.putWill(client, packet, err => {
+    t.error(err, 'no error')
+    instance.delWill(client, err => {
+      t.error(err, 'no error')
+      instance.getWill(client, (err, result) => {
+        t.error(err, 'no error')
+        t.false(result, 'will was not deleted')
+      })
+    })
+  })
+})
+
 test.onFinish(() => {
   process.exit(0)
 })


### PR DESCRIPTION
The `delWill` method is accessing the brokerId from client, which is undefined and therefore causing the key to not be deleted. This updates `delWill` to get the broker id from `this.broker.id` similar to how [getWill](https://github.com/moscajs/aedes-persistence-redis/blob/master/persistence.js#L503) is doing it.