### PR TITLE
chore: modernize dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['lts/-1', 'lts/*', 'node']
+        node-version: ['20', '22']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: ['lts/-1', 'lts/*', 'node']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Start Redis
         working-directory: ./docker
-        run:  docker-compose up -d
+        run:  docker compose up -d
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install
@@ -32,4 +32,4 @@ jobs:
           npm run test
       - name: Run tests - clusters
         run: |
-          node test-clusters.js
+          npm run test:clusters

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # aedes-persistence-redis
 
 ![.github/workflows/ci.yml](https://github.com/moscajs/aedes-persistence-redis/workflows/.github/workflows/ci.yml/badge.svg)
-[![Dependencies Status](https://david-dm.org/moscajs/aedes-persistence-redis/status.svg)](https://david-dm.org/moscajs/aedes-persistence-redis)
-[![devDependencies Status](https://david-dm.org/moscajs/aedes-persistence-redis/dev-status.svg)](https://david-dm.org/moscajs/aedes-persistence-redis?type=dev)
 \
 [![Known Vulnerabilities](https://snyk.io/test/github/moscajs/aedes-persistence-redis/badge.svg)](https://snyk.io/test/github/moscajs/aedes-persistence-redis)
 [![Coverage Status](https://coveralls.io/repos/moscajs/aedes-persistence-redis/badge.svg?branch=master&service=github)](https://coveralls.io/github/moscajs/aedes-persistence-redis?branch=master)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   redis-default:
     image: redis:6.2.5-alpine

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require('neostandard')({})

--- a/example.js
+++ b/example.js
@@ -4,6 +4,6 @@ const aedes = require('aedes')({
   mq,
   persistence
 })
-const server = require('net').createServer(aedes.handle)
+const server = require('node:net').createServer(aedes.handle)
 
 server.listen(1883)

--- a/migrations.js
+++ b/migrations.js
@@ -6,7 +6,7 @@ async function from9to10 (db, cb) {
   }
 
   // get all topics
-  db.hkeys(RETAINEDKEY, function (err, topics) {
+  db.hkeys(RETAINEDKEY, (err, topics) => {
     if (err) {
       return cb(err)
     }
@@ -14,17 +14,17 @@ async function from9to10 (db, cb) {
     Promise.all(topics.map(t => {
       return new Promise((resolve, reject) => {
         // get packet payload
-        db.hgetBuffer(RETAINEDKEY, t, function (err, payload) {
+        db.hgetBuffer(RETAINEDKEY, t, (err, payload) => {
           if (err) {
             return reject(err)
           }
           // set packet with new format
-          db.set(retainedKey(t), payload, function (err) {
+          db.set(retainedKey(t), payload, (err) => {
             if (err) {
               return reject(err)
             }
             // remove old packet
-            db.hdel(RETAINEDKEY, t, function (err) {
+            db.hdel(RETAINEDKEY, t, (err) => {
               if (err) {
                 return reject(err)
               }

--- a/package.json
+++ b/package.json
@@ -68,9 +68,6 @@
     "hashlru": "^2.3.0",
     "ioredis": "^5.5.0",
     "msgpack-lite": "^0.1.26",
-    "pump": "^3.0.2",
-    "qlobber": "^8.0.1",
-    "through2": "^4.0.2",
-    "throughv": "^1.0.4"
+    "qlobber": "^8.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,19 @@
   "version": "10.0.0",
   "description": "Aedes persistence, backed by redis",
   "main": "persistence.js",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
-    "lint": "standard --verbose | snazzy",
-    "test": "tape test.js | faucet",
-    "coverage": "nyc --reporter=lcov tape test.js",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
+    "unit": "node --test test.js",
+    "test": "npm run lint && npm run unit",
+    "test:clusters": "node --test test-clusters.js",
+    "coverage": "nyc --reporter=lcov node --test test.js",
     "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause;Apache-2.0;Apache*'",
-    "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
+    "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics",
+    "redis": "cd docker;docker compose up"
   },
   "release-it": {
     "github": {
@@ -27,7 +34,6 @@
     }
   },
   "pre-commit": [
-    "lint",
     "test"
   ],
   "repository": {
@@ -47,26 +53,23 @@
   },
   "homepage": "https://github.com/moscajs/aedes-persistence-redis#readme",
   "devDependencies": {
-    "fastq": "^1.13.0",
-    "faucet": "0.0.1",
+    "@fastify/pre-commit": "^2.2.0",
+    "eslint": "^9.21.0",
+    "fastq": "^1.19.1",
     "license-checker": "^25.0.1",
-    "mqemitter": "^4.5.0",
-    "mqemitter-redis": "^5.0.0",
-    "mqtt": "^4.3.7",
-    "nyc": "^15.1.0",
-    "pre-commit": "^1.2.2",
-    "release-it": "^15.0.0",
-    "snazzy": "^9.0.0",
-    "standard": "^17.0.0",
-    "tape": "^5.5.3"
+    "mqemitter-redis": "^6.1.0",
+    "mqtt": "^5.10.4",
+    "neostandard": "^0.12.1",
+    "nyc": "^17.1.0",
+    "release-it": "^18.1.2"
   },
   "dependencies": {
-    "aedes-cached-persistence": "^9.0.0",
+    "aedes-cached-persistence": "^10.0.0",
     "hashlru": "^2.3.0",
-    "ioredis": "^5.0.5",
+    "ioredis": "^5.5.0",
     "msgpack-lite": "^0.1.26",
-    "pump": "^3.0.0",
-    "qlobber": "^7.0.0",
+    "pump": "^3.0.2",
+    "qlobber": "^8.0.1",
     "through2": "^4.0.2",
     "throughv": "^1.0.4"
   }

--- a/persistence.js
+++ b/persistence.js
@@ -1,9 +1,6 @@
 const Redis = require('ioredis')
 const { Readable } = require('node:stream')
-const through = require('through2')
-const throughv = require('throughv')
 const msgpack = require('msgpack-lite')
-const pump = require('pump')
 const CachedPersistence = require('aedes-cached-persistence')
 const Packet = CachedPersistence.Packet
 const HLRU = require('hashlru')
@@ -61,10 +58,49 @@ function packetCountKey (brokerId, brokerCounter) {
   return `${PACKETKEY}${brokerId}:${brokerCounter}:offlineCount`
 }
 
+async function getDecodedValue (db, listKey, key) {
+  const value = await db.getBuffer(key)
+  const decoded = value ? msgpack.decode(value) : undefined
+  if (!decoded) {
+    db.lrem(listKey, 0, key)
+  }
+  return decoded
+}
+
+async function getRetainedKeys (db, hasClusters) {
+  if (hasClusters === true) {
+    // Get keys of all the masters
+    const masters = db.nodes('master')
+    const keys = await Promise.all(
+      masters.flatMap((node) => node.keys(ALL_RETAINEDKEYS))
+    )
+    return keys
+  }
+  return await db.hkeys(RETAINEDKEY)
+}
+
+async function getRetainedValue (db, topic, hasClusters) {
+  if (hasClusters === true) {
+    return msgpack.decode(await db.getBuffer(retainedKey(topic)))
+  }
+  return msgpack.decode(await db.hgetBuffer(RETAINEDKEY, topic))
+}
+
+async function * createWillStream (db, brokers, maxWills) {
+  const results = await db.lrange(WILLSKEY, 0, maxWills)
+  for (const key of results) {
+    const result = await getDecodedValue(db, WILLSKEY, key)
+    if (!brokers || !brokers[result.split(':')[1]]) {
+      yield result
+    }
+  }
+}
+
 class RedisPersistence extends CachedPersistence {
   constructor (opts = {}) {
     super(opts)
     this.maxSessionDelivery = opts.maxSessionDelivery || 1000
+    this.maxWills = 10000
     this.packetTTL = opts.packetTTL || (() => { return 0 })
 
     this.messageIdCache = HLRU(100000)
@@ -76,8 +112,6 @@ class RedisPersistence extends CachedPersistence {
     }
 
     this.hasClusters = !!opts.cluster
-    this._getRetainedChunkBound = (this.hasClusters ? this._getRetainedChunkCluster : this._getRetainedChunk).bind(this)
-    this._getRetainedKeysBound = (this.hasClusters ? this._getRetainedKeysCluster : this._getRetainedKeys).bind(this)
   }
 
   /**
@@ -108,52 +142,13 @@ class RedisPersistence extends CachedPersistence {
     }
   }
 
-  _getRetainedChunkCluster (topic, enc, cb) {
-    this._db.getBuffer(retainedKey(topic), cb)
-  }
-
-  _getRetainedChunk (topic, enc, cb) {
-    this._db.hgetBuffer(RETAINEDKEY, topic, cb)
-  }
-
-  _getRetainedKeysCluster (cb) {
-    // Get keys of all the masters:
-    const masters = this._db.nodes('master')
-    Promise.all(
-      masters
-        .map((node) => node.keys(ALL_RETAINEDKEYS))
-    ).then((keys) => {
-      // keys: [['key1', 'key2'], ['key3', 'key4']]
-      // flatten the array
-      cb(null, keys.reduce((acc, val) => acc.concat(val), []))
-    }).catch((err) => {
-      cb(err)
-    })
-  }
-
-  _getRetainedKeys (cb) {
-    this._db.hkeys(RETAINEDKEY, cb)
-  }
-
   createRetainedStreamCombi (patterns) {
-    const that = this
     const qlobber = new QlobberTrue(qlobberOpts)
 
     for (const pattern of patterns) {
       qlobber.add(pattern)
     }
-
-    const stream = through.obj(that._getRetainedChunkBound)
-
-    this._getRetainedKeysBound(function getKeys (err, keys) {
-      if (err) {
-        stream.emit('error', err)
-      } else {
-        matchRetained(stream, keys, qlobber, that.hasClusters)
-      }
-    })
-
-    return pump(stream, throughv.obj(decodeRetainedPacket))
+    return Readable.from(matchRetained(this.db, qlobber, this.hasClusters))
   }
 
   createRetainedStream (pattern) {
@@ -271,35 +266,22 @@ class RedisPersistence extends CachedPersistence {
     cb(null, result)
   }
 
-  _setup () {
+  async _setup () {
     if (this.ready) {
       return
     }
 
-    const that = this
-
-    const hgetallStream = throughv.obj(function getStream (clientId, enc, cb) {
-      that._db.hgetallBuffer(clientSubKey(clientId), function clientHash (err, hash) {
-        cb(err, { clientHash: hash, clientId })
-      })
-    }, function emitReady (cb) {
-      that.ready = true
-      that.emit('ready')
-      cb()
-    }).on('data', function processKeys (data) {
-      processKeysForClient(data.clientId, data.clientHash, that)
-    })
-
-    this._db.smembers(CLIENTSKEY, function smembers (err, clientIds) {
-      if (err) {
-        hgetallStream.emit('error', err)
-      } else {
-        for (const clientId of clientIds) {
-          hgetallStream.write(clientId)
-        }
-        hgetallStream.end()
+    try {
+      const clientIds = await this._db.smembers(CLIENTSKEY)
+      for await (const clientId of clientIds) {
+        const clientHash = await this._db.hgetallBuffer(clientSubKey(clientId))
+        processKeysForClient(clientId, clientHash, this._trie)
       }
-    })
+      this.ready = true
+      this.emit('ready')
+    } catch (err) {
+      this.emit('error', err)
+    }
   }
 
   outgoingEnqueue (sub, packet, cb) {
@@ -441,22 +423,17 @@ class RedisPersistence extends CachedPersistence {
 
   outgoingStream (client) {
     const clientListKey = outgoingKey(client.id)
-    const stream = throughv.obj(this._buildAugment(clientListKey))
+    const db = this._db
+    const maxSessionDelivery = this.maxSessionDelivery
 
-    this._db.lrange(clientListKey, 0, this.maxSessionDelivery, lrangeResult)
-
-    function lrangeResult (err, results) {
-      if (err) {
-        stream.emit('error', err)
-      } else {
-        for (const result of results) {
-          stream.write(result)
-        }
-        stream.end()
+    async function * lrangeResult () {
+      const results = await db.lrange(clientListKey, 0, maxSessionDelivery)
+      for (const key of results) {
+        yield getDecodedValue(db, clientListKey, key)
       }
     }
 
-    return stream
+    return Readable.from(lrangeResult())
   }
 
   incomingStorePacket (client, packet, cb) {
@@ -533,23 +510,7 @@ class RedisPersistence extends CachedPersistence {
   }
 
   streamWill (brokers) {
-    const stream = throughv.obj(this._buildAugment(WILLSKEY))
-
-    this._db.lrange(WILLSKEY, 0, 10000, streamWill)
-
-    function streamWill (err, results) {
-      if (err) {
-        stream.emit('error', err)
-      } else {
-        for (const result of results) {
-          if (!brokers || !brokers[result.split(':')[1]]) {
-            stream.write(result)
-          }
-        }
-        stream.end()
-      }
-    }
-    return stream
+    return Readable.from(createWillStream(this._db, brokers, this.maxWills))
   }
 
   * #getClientIdFromEntries (entries) {
@@ -591,18 +552,13 @@ class RedisPersistence extends CachedPersistence {
   }
 }
 
-function matchRetained (stream, topics, qlobber, hasClusters) {
-  for (let t of topics) {
-    t = hasClusters ? decodeURIComponent(t.split(':')[1]) : t
-    if (qlobber.test(t)) {
-      stream.write(t)
+function * matchRetained (db, qlobber, hasClusters) {
+  for (const key of getRetainedKeys(db, hasClusters)) {
+    const topic = hasClusters ? decodeURIComponent(key.split(':')[1]) : key
+    if (qlobber.test(topic)) {
+      yield getRetainedValue(db, topic, hasClusters)
     }
   }
-  stream.end()
-}
-
-function decodeRetainedPacket (chunk, enc, cb) {
-  cb(null, msgpack.decode(chunk))
 }
 
 function toSub (topic) {
@@ -634,12 +590,12 @@ function returnSubsForClient (subs) {
   return toReturn
 }
 
-function processKeysForClient (clientId, clientHash, that) {
+function processKeysForClient (clientId, clientHash, trie) {
   const topics = Object.keys(clientHash)
   for (const topic of topics) {
     const sub = msgpack.decode(clientHash[topic])
     sub.clientId = clientId
-    that._trie.add(topic, sub)
+    trie.add(topic, sub)
   }
 }
 

--- a/persistence.js
+++ b/persistence.js
@@ -1,5 +1,5 @@
 const Redis = require('ioredis')
-const { Readable } = require('stream')
+const { Readable } = require('node:stream')
 const through = require('through2')
 const throughv = require('throughv')
 const msgpack = require('msgpack-lite')
@@ -256,7 +256,7 @@ class RedisPersistence extends CachedPersistence {
         return cb(err)
       }
 
-      cb(null, that._trie.subscriptionsCount, parseInt(count) || 0)
+      cb(null, that._trie.subscriptionsCount, Number.parseInt(count) || 0)
     })
   }
 
@@ -624,7 +624,7 @@ function returnSubsForClient (subs) {
     if (subs[subKey].length === 1) { // version 8x fallback, QoS saved not encoded object
       toReturn.push({
         topic: subKey,
-        qos: parseInt(subs[subKey])
+        qos: Number.parseInt(subs[subKey])
       })
     } else {
       toReturn.push(msgpack.decode(subs[subKey]))
@@ -653,9 +653,8 @@ function updateWithClientData (that, client, packet, cb) {
     that.messageIdCache.set(messageIdKey, pktKey)
     if (ttl > 0) {
       return that._db.set(pktKey, msgpack.encode(packet), 'EX', ttl, updatePacket)
-    } else {
-      return that._db.set(pktKey, msgpack.encode(packet), updatePacket)
     }
+    return that._db.set(pktKey, msgpack.encode(packet), updatePacket)
   }
 
   // qos=2

--- a/test-clusters.js
+++ b/test-clusters.js
@@ -1,4 +1,4 @@
-const test = require('tape').test
+const test = require('node:test')
 const persistence = require('./persistence')
 const Redis = require('ioredis')
 const mqemitterRedis = require('mqemitter-redis')
@@ -6,6 +6,10 @@ const abs = require('aedes-cached-persistence/abstract')
 
 function unref () {
   this.connector.stream.unref()
+}
+
+function sleep (sec) {
+  return new Promise(resolve => setTimeout(resolve, sec * 1000))
 }
 
 const nodes = [
@@ -23,41 +27,43 @@ db.on('error', e => {
   console.trace(e)
 })
 
-db.on('ready', function () {
+function buildEmitter () {
+  const emitter = mqemitterRedis()
+  emitter.subConn.on('connect', unref)
+  emitter.pubConn.on('connect', unref)
+
+  return emitter
+}
+
+function clusterPersistence (cb) {
+  const slaves = db.nodes('master')
+  Promise.all(slaves.map((node) => {
+    return node.flushdb().catch(err => {
+      console.error('flushRedisKeys-error:', err)
+    })
+  })).then(() => {
+    const conn = new Redis.Cluster(nodes)
+
+    conn.on('error', e => {
+      console.trace(e)
+    })
+
+    conn.on('ready', () => {
+      cb(null, persistence({
+        conn,
+        cluster: true
+      }))
+    })
+  })
+}
+
+db.on('ready', () => {
   abs({
     test,
-    buildEmitter () {
-      const emitter = mqemitterRedis()
-      emitter.subConn.on('connect', unref)
-      emitter.pubConn.on('connect', unref)
-
-      return emitter
-    },
-    persistence (cb) {
-      const slaves = db.nodes('master')
-      Promise.all(slaves.map(function (node) {
-        return node.flushdb().catch(err => {
-          console.error('flushRedisKeys-error:', err)
-        })
-      })).then(() => {
-        const conn = new Redis.Cluster(nodes)
-
-        conn.on('error', e => {
-          console.trace(e)
-        })
-
-        conn.on('ready', function () {
-          cb(null, persistence({
-            conn,
-            cluster: true
-          }))
-        })
-      })
-    },
+    buildEmitter,
+    persistence: clusterPersistence,
     waitForReady: true
   })
-
-  test.onFinish(() => {
-    process.exit(0)
-  })
 })
+
+sleep(10).then(() => process.exit())

--- a/test-clusters.js
+++ b/test-clusters.js
@@ -66,4 +66,4 @@ db.on('ready', () => {
   })
 })
 
-sleep(10).then(() => process.exit())
+sleep(10).then(() => process.exit(0))

--- a/test.js
+++ b/test.js
@@ -10,10 +10,10 @@ function sleep (sec) {
 
 function waitForEvent (obj, resolveEvt) {
   return new Promise((resolve, reject) => {
-    obj.on(resolveEvt, () => {
+    obj.once(resolveEvt, () => {
       resolve()
     })
-    obj.on('error', reject)
+    obj.once('error', reject)
   })
 }
 

--- a/test.js
+++ b/test.js
@@ -83,7 +83,7 @@ abs({
 })
 
 test('packet ttl', async t => {
-  t.plan(2)
+  t.plan(3)
   // the promise is required for the test to wait for the end event
   const executeTest = new Promise((resolve, reject) => {
     db.flushall()
@@ -114,13 +114,11 @@ test('packet ttl', async t => {
       t.assert.deepEqual(saved, packet)
       await sleep(1)
       const offlineStream = instance.outgoingStream({ id: 'ttlTest' })
-      offlineStream.on('data', offlinePacket => {
+      for await (const offlinePacket of offlineStream) {
         t.assert.ok(!offlinePacket)
-      })
-      offlineStream.on('end', () => {
-        cleanUpPersistence(t, p)
-        resolve()
-      })
+      }
+      cleanUpPersistence(t, p)
+      resolve()
     })
   })
   await executeTest

--- a/tester.js
+++ b/tester.js
@@ -1,4 +1,3 @@
-// npm install mqtt fastq
 // command to run : node fastbench 25000
 const queue = require('fastq')(worker, 1)
 const mqtt = require('mqtt')


### PR DESCRIPTION
This PR closes: #111, it:
- updates CI 
  - to use the lastest versions of NodeJS and actions
  - use `docker compose` instead of `docker-compose` which is not supported on `Ubuntu:latest` action runners anymore
  - uses npm commands to run all tests for more flexibility
- replaces `standard` & `snappy` by `eslint` & `neostandard`
- replaces `tape` & `faucet` by `node:test`
- removes all unused dependencies
- updates all dependencies  to their latest versions
- applies various lint fixes
- removes defunct badges from README.md

Enjoy!

Kind regards,
Hans