### PR TITLE
fix: error 'getRetainedKeys is not a function or its return value is not iterable'

### DIFF
--- a/persistence.js
+++ b/persistence.js
@@ -105,14 +105,13 @@ class RedisPersistence extends CachedPersistence {
 
     this.messageIdCache = HLRU(100000)
 
-    const hasClusters = opts.cluster && Array.isArray(opts.cluster)
-    this.hasClusters = hasClusters
-
-    if (hasClusters) {
+    if (opts.cluster && Array.isArray(opts.cluster)) {
       this._db = new Redis.Cluster(opts.cluster)
     } else {
       this._db = opts.conn || new Redis(opts)
     }
+
+    this.hasClusters = !!opts.cluster
   }
 
   /**

--- a/persistence.js
+++ b/persistence.js
@@ -684,7 +684,3 @@ function augmentWithBrokerData (that, client, packet, cb) {
 }
 
 module.exports = (opts) => new RedisPersistence(opts)
-module.exports.forTesting = {
-  qlobberOpts,
-  matchRetained
-}

--- a/persistence.js
+++ b/persistence.js
@@ -148,6 +148,7 @@ class RedisPersistence extends CachedPersistence {
     for (const pattern of patterns) {
       qlobber.add(pattern)
     }
+
     return Readable.from(matchRetained(this._db, qlobber, this.hasClusters))
   }
 
@@ -683,3 +684,7 @@ function augmentWithBrokerData (that, client, packet, cb) {
 }
 
 module.exports = (opts) => new RedisPersistence(opts)
+module.exports.forTesting = {
+  qlobberOpts,
+  matchRetained
+}

--- a/persistence.js
+++ b/persistence.js
@@ -105,13 +105,14 @@ class RedisPersistence extends CachedPersistence {
 
     this.messageIdCache = HLRU(100000)
 
-    if (opts.cluster && Array.isArray(opts.cluster)) {
+    const hasClusters = opts.cluster && Array.isArray(opts.cluster)
+    this.hasClusters = hasClusters
+
+    if (hasClusters) {
       this._db = new Redis.Cluster(opts.cluster)
     } else {
       this._db = opts.conn || new Redis(opts)
     }
-
-    this.hasClusters = !!opts.cluster
   }
 
   /**
@@ -148,7 +149,7 @@ class RedisPersistence extends CachedPersistence {
     for (const pattern of patterns) {
       qlobber.add(pattern)
     }
-    return Readable.from(matchRetained(this.db, qlobber, this.hasClusters))
+    return Readable.from(matchRetained(this._db, qlobber, this.hasClusters))
   }
 
   createRetainedStream (pattern) {
@@ -552,8 +553,8 @@ class RedisPersistence extends CachedPersistence {
   }
 }
 
-function * matchRetained (db, qlobber, hasClusters) {
-  for (const key of getRetainedKeys(db, hasClusters)) {
+async function * matchRetained (db, qlobber, hasClusters) {
+  for (const key of await getRetainedKeys(db, hasClusters)) {
     const topic = hasClusters ? decodeURIComponent(key.split(':')[1]) : key
     if (qlobber.test(topic)) {
       yield getRetainedValue(db, topic, hasClusters)

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ const persistence = require('./')
 const Redis = require('ioredis')
 const mqemitterRedis = require('mqemitter-redis')
 const abs = require('aedes-cached-persistence/abstract')
+
 function sleep (sec) {
   return new Promise(resolve => setTimeout(resolve, sec * 1000))
 }

--- a/test.js
+++ b/test.js
@@ -3,7 +3,6 @@ const persistence = require('./')
 const Redis = require('ioredis')
 const mqemitterRedis = require('mqemitter-redis')
 const abs = require('aedes-cached-persistence/abstract')
-const { QlobberTrue } = require('qlobber')
 function sleep (sec) {
   return new Promise(resolve => setTimeout(resolve, sec * 1000))
 }
@@ -310,41 +309,6 @@ test('wills table de-duplicate', async t => {
         })
         wills.on('end', () => {
           t.assert.equal(willCount, 1, 'should only be one will')
-          cleanUpPersistence(t, p)
-          resolve()
-        })
-      })
-    })
-  })
-  await executeTest
-})
-
-test('matchRetained properly retrieves retained packets', async t => {
-  t.plan(2)
-  const executeTest = new Promise((resolve, reject) => {
-    db.flushall()
-    const p = setUpPersistence(t, '1')
-    const instance = p.instance
-
-    const packet = {
-      cmd: 'publish',
-      topic: 'hello',
-      payload: 'test',
-      qos: 1,
-      retain: true,
-      brokerId: instance.broker.id,
-      brokerCounter: 42,
-      messageId: 123
-    }
-
-    const qlobber = new QlobberTrue(persistence.forTesting.qlobberOpts)
-    qlobber.add(packet.topic)
-
-    instance.on('ready', () => {
-      instance.storeRetained(packet, err => {
-        t.assert.ok(!err, 'no error on storeRetained')
-        persistence.forTesting.matchRetained(db, qlobber, false).next().then(retained => {
-          t.assert.deepEqual(retained.value, packet, 'retained packet matches original packet')
           cleanUpPersistence(t, p)
           resolve()
         })

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ const persistence = require('./')
 const Redis = require('ioredis')
 const mqemitterRedis = require('mqemitter-redis')
 const abs = require('aedes-cached-persistence/abstract')
-
+const { QlobberTrue } = require('qlobber')
 function sleep (sec) {
   return new Promise(resolve => setTimeout(resolve, sec * 1000))
 }
@@ -310,6 +310,41 @@ test('wills table de-duplicate', async t => {
         })
         wills.on('end', () => {
           t.assert.equal(willCount, 1, 'should only be one will')
+          cleanUpPersistence(t, p)
+          resolve()
+        })
+      })
+    })
+  })
+  await executeTest
+})
+
+test('matchRetained properly retrieves retained packets', async t => {
+  t.plan(2)
+  const executeTest = new Promise((resolve, reject) => {
+    db.flushall()
+    const p = setUpPersistence(t, '1')
+    const instance = p.instance
+
+    const packet = {
+      cmd: 'publish',
+      topic: 'hello',
+      payload: 'test',
+      qos: 1,
+      retain: true,
+      brokerId: instance.broker.id,
+      brokerCounter: 42,
+      messageId: 123
+    }
+
+    const qlobber = new QlobberTrue(persistence.forTesting.qlobberOpts)
+    qlobber.add(packet.topic)
+
+    instance.on('ready', () => {
+      instance.storeRetained(packet, err => {
+        t.assert.ok(!err, 'no error on storeRetained')
+        persistence.forTesting.matchRetained(db, qlobber, false).next().then(retained => {
+          t.assert.deepEqual(retained.value, packet, 'retained packet matches original packet')
           cleanUpPersistence(t, p)
           resolve()
         })


### PR DESCRIPTION
- I'm getting this error when trying to use the plugin on the latest version out of the box: `Fix for error 'getRetainedKeys is not a function or its return value is not iterable'`. Specifically, this happens when I try to subscribe to a topic with a retained message (maybe without as well, haven't tested that).
- changed `this.db` reference to `this._db`.
- added `await` to `getRetainedKeys` call since it was returning a promise instead of a value.
- a test is failing for `ttl`, but it was already failing before I made any changes and seems unrelated to this functionality.
- added a test to validate and I've checked that it fails before I made the change, but passes after the change.
- I used the `forTesting` convention on exporting things for testing, but I'd happily take some guidance on the preferred way to use unexported functions in testing. I tried to only export when NODE_ENV was set to a `test`, but realized that wasn't actually being set anywhere, and I assumed adding it in a way that is portable across platforms might be a pain, or at least a little more than I wanted to do here, so `forTesting` is what I went with.