### PR TITLE
fix: serialize test file execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "unit": "node --test --test-timeout=180000 test/*.js",
+    "unit": "node --test --test-timeout=180000 --test-concurrency=1 test/*.js",
     "test": "npm run lint && npm run unit",
     "coverage": "c8 --reporter=lcov npm run unit",
     "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause;Apache-2.0;Apache*'",


### PR DESCRIPTION
This PR serializes execution of test files to avoid problems caused  by tests running in parallel influencing each other.

See https://github.com/moscajs/aedes-persistence-mongodb/pull/84 for a full description of the problem.

Kind regards,
Hans