### PR TITLE
Use aedes persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "mqemitter-redis": "^7.0.0",
     "mqtt": "^5.13.0",
     "neostandard": "^0.12.1",
-    "release-it": "^19.0.2"
+    "release-it": "^19.0.3"
   },
   "dependencies": {
-    "aedes-persistence": "github:seriousme/aedes-persistence#asyncify",
+    "aedes-persistence": "^10.2.0",
     "hashlru": "^2.3.0",
     "ioredis": "^5.6.1",
     "msgpack-lite": "^0.1.26",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "release-it": "^19.0.2"
   },
   "dependencies": {
-    "aedes-cached-persistence": "^10.1.1",
+    "aedes-persistence": "github:seriousme/aedes-persistence#asyncify",
     "hashlru": "^2.3.0",
     "ioredis": "^5.6.1",
     "msgpack-lite": "^0.1.26",

--- a/persistence.js
+++ b/persistence.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { CallBackPersistence } = require('aedes-cached-persistence/callBackPersistence.js')
+const { CallBackPersistence } = require('aedes-persistence/callBackPersistence.js')
 const AsyncPersistence = require('./asyncPersistence.js')
 const asyncInstanceFactory = (opts) => new AsyncPersistence(opts)
 module.exports = (opts) => new CallBackPersistence(asyncInstanceFactory, opts)

--- a/test/abs.js
+++ b/test/abs.js
@@ -2,7 +2,7 @@ const test = require('node:test')
 const persistence = require('../persistence.js')
 const Redis = require('ioredis')
 const mqemitterRedis = require('mqemitter-redis')
-const abs = require('aedes-cached-persistence/abstract')
+const abs = require('aedes-persistence/abstract')
 const { once } = require('node:events')
 
 function sleep (sec) {

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -2,7 +2,7 @@ const test = require('node:test')
 const persistence = require('../persistence.js')
 const Redis = require('ioredis')
 const mqemitterRedis = require('mqemitter-redis')
-const abs = require('aedes-cached-persistence/abstract')
+const abs = require('aedes-persistence/abstract')
 const { once } = require('node:events')
 
 const nodes = [

--- a/test/own.js
+++ b/test/own.js
@@ -2,7 +2,7 @@ const test = require('node:test')
 const persistence = require('../persistence.js')
 const Redis = require('ioredis')
 const mqemitterRedis = require('mqemitter-redis')
-const { PromisifiedPersistence } = require('aedes-cached-persistence/promisified.js')
+const { PromisifiedPersistence } = require('aedes-persistence/promisified.js')
 const { once } = require('node:events')
 
 // helpers


### PR DESCRIPTION
This PR :

- moves subscription added/removed from callbackifiedPersistence into asyncPersistence so the async interface is fully self supporting.
- lets go of aedes-cached-persistence and only relies on aedes-persistence for common aedes related functionality
- privatizes class variables where possible to enforce strict interfaces
- updates all release-it to its latest version.

Kind regards,
Hans