### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,16 +54,16 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.0",
     "c8": "^10.1.3",
-    "eslint": "^9.26.0",
+    "eslint": "^9.30.1",
     "fastq": "^1.19.1",
     "license-checker": "^25.0.1",
     "mqemitter-redis": "^7.0.0",
-    "mqtt": "^5.13.0",
-    "neostandard": "^0.12.1",
+    "mqtt": "^5.13.2",
+    "neostandard": "^0.12.2",
     "release-it": "^19.0.3"
   },
   "dependencies": {
-    "aedes-persistence": "^10.2.0",
+    "aedes-persistence": "^10.2.2",
     "hashlru": "^2.3.0",
     "ioredis": "^5.6.1",
     "msgpack-lite": "^0.1.26",


### PR DESCRIPTION
This PR updates:
-  aedes-persistence  ^10.2.0  →  ^10.2.2
-  eslint       ^9.26.0  →  ^9.30.1
-  mqtt         ^5.13.0  →  ^5.13.2
-  neostandard  ^0.12.1  →  ^0.12.2